### PR TITLE
Add proxy configuration and secure API key storage

### DIFF
--- a/app_src/SETTINGS.json
+++ b/app_src/SETTINGS.json
@@ -1,0 +1,17 @@
+{
+  "ui": {
+    "fullscreen_borderless": true,
+    "show_session_timer": true
+  },
+  "translation": {
+    "provider": "gemini",
+    "transliteration": "off"
+  },
+  "api": {
+    "GEMINI_API_KEY": ""
+  },
+  "network": {
+    "http_proxy": "",
+    "https_proxy": ""
+  }
+}

--- a/app_src/SETTINGS_SCHEMA.json
+++ b/app_src/SETTINGS_SCHEMA.json
@@ -1,0 +1,17 @@
+{
+  "ui": {
+    "fullscreen_borderless": true,
+    "show_session_timer": true
+  },
+  "translation": {
+    "provider": "gemini",
+    "transliteration": "off"
+  },
+  "api": {
+    "GEMINI_API_KEY": ""
+  },
+  "network": {
+    "http_proxy": "",
+    "https_proxy": ""
+  }
+}

--- a/app_src/app.py
+++ b/app_src/app.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+import sys
+from pathlib import Path
+from datetime import datetime
+from threading import Thread, Event
+import os
+
+from PySide6.QtCore import Qt, QSettings, Signal, QObject, QByteArray
+from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QFileDialog, QSplitter, QVBoxLayout, QHBoxLayout,
+    QLabel, QPushButton, QListWidget, QListWidgetItem, QFrame, QLineEdit,
+    QMessageBox, QPlainTextEdit, QProgressBar, QSizePolicy
+)
+
+APP_ORG = "DeepParser"
+APP_NAME = "Парсер веб-новелл"
+DEFAULT_ACCENT = "#00E5FF"
+
+from site_profiles import detect_profile
+from utils_docx import save_chapter_docx
+from settings.network import load_proxy_settings, test_proxy_connection
+from settings.credentials import load_api_key
+
+def ensure_dir(p: Path):
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+class Signals(QObject):
+    progress = Signal(int, str)
+    done = Signal(str)
+    error = Signal(str)
+
+class ProjectStore:
+    def __init__(self, workdir: Path):
+        self.workdir = workdir
+        self.db = ensure_dir(workdir) / "config.db"
+        import sqlite3
+        conn = sqlite3.connect(self.db); cur = conn.cursor()
+        cur.execute("""CREATE TABLE IF NOT EXISTS projects(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );""")
+        conn.commit(); conn.close()
+    def list(self, status="active"):
+        import sqlite3
+        conn = sqlite3.connect(self.db); cur = conn.cursor()
+        cur.execute("SELECT id,name,status,created_at,updated_at FROM projects WHERE status=? ORDER BY id DESC",(status,))
+        rows = cur.fetchall(); conn.close(); return rows
+    def create(self, name: str):
+        import sqlite3
+        now = datetime.utcnow().isoformat()
+        conn = sqlite3.connect(self.db); cur = conn.cursor()
+        cur.execute("INSERT INTO projects(name,status,created_at,updated_at) VALUES(?, 'active', ?, ?)", (name, now, now))
+        conn.commit(); pid = cur.lastrowid; conn.close()
+        base = ensure_dir(self.workdir / name)
+        ensure_dir(base / "Original"); ensure_dir(base / "Translation")
+        return pid
+
+class ProjectPanel(QFrame):
+    def __init__(self, store: ProjectStore, on_select):
+        super().__init__(); self.store=store; self.on_select=on_select
+        self.setMinimumWidth(220)
+        self.setMaximumWidth(6000)
+
+        v = QVBoxLayout(self); v.setContentsMargins(8,8,8,8); v.setSpacing(6)
+        self.left_split = QSplitter(Qt.Vertical)
+        v.addWidget(self.left_split)
+
+        # Projects block
+        proj_block = QFrame(); pv = QVBoxLayout(proj_block); pv.setContentsMargins(0,0,0,0); pv.setSpacing(6)
+        head = QHBoxLayout(); head.addWidget(QLabel("Проекты"))
+        self.btn_add = QPushButton("+"); self.btn_add.setFixedWidth(28); self.btn_add.clicked.connect(self._add)
+        head.addStretch(1); head.addWidget(self.btn_add); pv.addLayout(head)
+        self.active = QListWidget(); self.active.setMinimumHeight(120)
+        self.active.itemClicked.connect(lambda it:self.on_select(it.data(Qt.UserRole)))
+        pv.addWidget(self.active)
+
+        # Archive block
+        arch_block = QFrame(); av = QVBoxLayout(arch_block); av.setContentsMargins(0,0,0,0); av.setSpacing(6)
+        arch_head = QHBoxLayout(); arch_head.addWidget(QLabel("Архив")); arch_head.addStretch(1); av.addLayout(arch_head)
+        self.archive = QListWidget(); self.archive.setMinimumHeight(80)
+        self.archive.itemClicked.connect(lambda it:self.on_select(it.data(Qt.UserRole)))
+        av.addWidget(self.archive)
+
+        self.left_split.addWidget(proj_block)
+        self.left_split.addWidget(arch_block)
+        self.left_split.setSizes([300,150])
+
+        self.refresh()
+
+    def refresh(self):
+        self.active.clear(); self.archive.clear()
+        for r in self.store.list("active"):
+            it=QListWidgetItem(r[1]); it.setData(Qt.UserRole, r[0]); self.active.addItem(it)
+        for r in self.store.list("archived"):
+            it=QListWidgetItem(r[1]); it.setData(Qt.UserRole, r[0]); self.archive.addItem(it)
+
+    def _add(self):
+        from PySide6.QtWidgets import QInputDialog
+        name, ok = QInputDialog.getText(self,"Новый проект","Название:")
+        if ok and name.strip():
+            self.store.create(name.strip())
+            self.refresh()
+
+class ParserPanel(QFrame):
+    def __init__(self, on_parse, on_pause, on_stop):
+        super().__init__()
+        lay = QHBoxLayout(self); lay.setContentsMargins(8,8,8,8); lay.setSpacing(8)
+        self.url = QLineEdit(); self.url.setPlaceholderText("Вставьте ссылку на книгу…")
+        self.btn_parse = QPushButton("Спарсить")
+        self.btn_pause = QPushButton("Пауза")
+        self.btn_stop = QPushButton("Стоп")
+        self.progress = QProgressBar(); self.progress.setMinimum(0); self.progress.setMaximum(100)
+        self.btn_parse.clicked.connect(lambda: on_parse(self.url.text().strip()))
+        self.btn_pause.clicked.connect(on_pause)
+        self.btn_stop.clicked.connect(on_stop)
+        lay.addWidget(QLabel("Ссылка:")); lay.addWidget(self.url,1); lay.addWidget(self.btn_parse)
+        lay.addWidget(self.btn_pause); lay.addWidget(self.btn_stop); lay.addWidget(self.progress,1)
+
+class EditorArea(QFrame):
+    def __init__(self):
+        super().__init__()
+        self.signals = Signals()
+        self._thread = None
+        self._pause = Event(); self._stop = Event()
+        self._pause.clear(); self._stop.clear()
+        self.project_path: Path|None = None
+
+        v = QVBoxLayout(self); v.setContentsMargins(8,8,8,8); v.setSpacing(8)
+        self.panel = ParserPanel(self._start_parse, self._toggle_pause, self._stop_parse)
+        v.addWidget(self.panel)
+
+        self.split = QSplitter(Qt.Vertical); v.addWidget(self.split,1)
+        top = QSplitter(Qt.Horizontal)
+        self.orig = QPlainTextEdit(); self.orig.setPlaceholderText("Оригинал главы…")
+        self.tran = QPlainTextEdit(); self.tran.setPlaceholderText("Перевод главы…")
+        top.addWidget(self.orig); top.addWidget(self.tran); top.setSizes([600,600])
+        self.split.addWidget(top)
+        bottom = QFrame(); vb=QVBoxLayout(bottom); vb.setContentsMargins(0,0,0,0); vb.addWidget(QLabel("Мини‑промпт")); self.prompt = QPlainTextEdit(); vb.addWidget(self.prompt); self.split.addWidget(bottom); self.split.setSizes([800,200])
+
+        self.signals.progress.connect(self._on_progress)
+        self.signals.done.connect(self._on_done)
+        self.signals.error.connect(self._on_error)
+
+    def bind_project(self, project_path: Path):
+        self.project_path = project_path
+
+    def _start_parse(self, url: str):
+        if not url: QMessageBox.warning(self,"Нет ссылки","Вставьте ссылку."); return
+        prof = detect_profile(url)
+        if not prof: QMessageBox.warning(self,"Неизвестный сайт","Пока не поддерживается."); return
+        if self._thread and self._thread.is_alive(): QMessageBox.information(self,"Идёт парсинг","Дождитесь завершения/остановите."); return
+
+        self._pause.clear(); self._stop.clear()
+
+        def worker():
+            try:
+                book, chapters = prof.parse_book(url)
+                if not chapters: self.signals.error.emit("Не удалось найти главы."); return
+                base = self.project_path or Path.cwd()
+                target = ensure_dir(base / "Original" / book)
+                total = len(chapters)
+                for i, ch in enumerate(chapters, start=1):
+                    while self._pause.is_set():
+                        import time; time.sleep(0.2)
+                        if self._stop.is_set(): break
+                    if self._stop.is_set(): break
+
+                    self.signals.progress.emit(int((i-1)/total*100), f"Глава {i}/{total}: {ch.title}")
+                    title, body = prof.fetch_chapter(ch.url)
+                    save_chapter_docx(target, title or ch.title, body or "", index=i)
+                if not self._stop.is_set():
+                    self.signals.progress.emit(100, "Готово")
+                    self.signals.done.emit(str(target))
+            except Exception as e:
+                self.signals.error.emit(str(e))
+
+        self._thread = Thread(target=worker, daemon=True); self._thread.start()
+
+    def _toggle_pause(self):
+        if self._pause.is_set():
+            self._pause.clear()
+            self.panel.btn_pause.setText("Пауза")
+        else:
+            self._pause.set()
+            self.panel.btn_pause.setText("Продолжить")
+
+    def _stop_parse(self):
+        self._stop.set()
+        self._pause.clear()
+        self.panel.btn_pause.setText("Пауза")
+
+    def _on_progress(self, p: int, msg: str):
+        self.panel.progress.setValue(p); self.panel.progress.setFormat(msg+" (%p%)")
+
+    def _on_done(self, folder: str):
+        QMessageBox.information(self, "Парсинг завершён", f"Файлы сохранены в:\n{folder}")
+
+    def _on_error(self, err: str):
+        QMessageBox.critical(self, "Ошибка парсинга", err)
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle(APP_NAME); self.resize(1400,900)
+        self.settings = QSettings(APP_ORG, APP_NAME)
+
+        self.workdir = self._ensure_workdir()
+        self.store = ProjectStore(Path(self.workdir))
+
+        root = QWidget(); self.setCentralWidget(root)
+        lay = QVBoxLayout(root); lay.setContentsMargins(0,0,0,0); lay.setSpacing(0)
+
+        # Top bar
+        top_bar = QHBoxLayout(); top_bar.setContentsMargins(8,6,8,6); top_bar.setSpacing(8)
+        self.btn_burger = QPushButton("☰"); self.btn_burger.setFixedWidth(32); self.btn_burger.clicked.connect(self._toggle_left_panel)
+        self.btn_fullscreen = QPushButton("⛶"); self.btn_fullscreen.setFixedWidth(32); self.btn_fullscreen.clicked.connect(self._toggle_fullscreen)
+        title = QLabel(APP_NAME)
+        top_bar.addWidget(self.btn_burger); top_bar.addWidget(title); top_bar.addStretch(1); top_bar.addWidget(self.btn_fullscreen)
+        lay.addLayout(top_bar)
+
+        # Main splitter: left | editor
+        self.main_split = QSplitter(Qt.Horizontal); lay.addWidget(self.main_split,1)
+        self.left_panel = ProjectPanel(self.store, on_select=self._bind_project)
+        self.main_split.addWidget(self.left_panel)
+        self.editor = EditorArea(); self.main_split.addWidget(self.editor)
+        self.main_split.setCollapsible(0, True)
+        self.main_split.setSizes([280, 1120])
+
+        # Shortcuts
+        act_toggle = QAction("Скрыть/показать левую панель", self); act_toggle.setShortcut(QKeySequence("Ctrl+B")); act_toggle.triggered.connect(self._toggle_left_panel); self.addAction(act_toggle)
+        act_full = QAction("Полноэкранный", self); act_full.setShortcut(QKeySequence("F11")); act_full.triggered.connect(self._toggle_fullscreen); self.addAction(act_full)
+        act_esc = QAction("Выход из полноэкранного", self); act_esc.setShortcut(QKeySequence("Esc")); act_esc.triggered.connect(self._exit_fullscreen); self.addAction(act_esc)
+
+        # Restore splitter state
+        bs = self.settings.value("ui/main_split_state", None)
+        if isinstance(bs, QByteArray):
+            self.main_split.restoreState(bs)
+
+    def _toggle_left_panel(self):
+        if self.left_panel.isVisible():
+            self.main_split.setSizes([0, 1])
+            self.left_panel.setVisible(False)
+        else:
+            self.left_panel.setVisible(True)
+            self.main_split.setSizes([280, 1120])
+        self.settings.setValue("ui/main_split_state", self.main_split.saveState())
+
+    def _toggle_fullscreen(self):
+        if self.isFullScreen():
+            self.showNormal()
+        else:
+            self.showFullScreen()
+
+    def _exit_fullscreen(self):
+        if self.isFullScreen():
+            self.showNormal()
+
+    def _ensure_workdir(self)->str:
+        wd = self.settings.value("app/workdir","")
+        if wd and Path(wd).exists(): return wd
+        dlg = QFileDialog(self,"Выберите рабочую папку")
+        dlg.setFileMode(QFileDialog.Directory); dlg.setOption(QFileDialog.ShowDirsOnly, True); dlg.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+        if dlg.exec(): chosen = dlg.selectedFiles()[0]
+        else:
+            chosen = str(Path.home() / "Documents" / "Парсер веб-новелл"); ensure_dir(Path(chosen))
+        self.settings.setValue("app/workdir", chosen); return chosen
+
+    def _bind_project(self, pid: int):
+        rows = self.store.list("active")
+        name = next((r[1] for r in rows if r[0]==pid), None)
+        if name: self.editor.bind_project(Path(self.workdir)/name)
+
+def main():
+    proxies = load_proxy_settings()
+    if not test_proxy_connection(proxies):
+        print("Warning: proxy connection failed")
+    proxies.apply()
+    os.environ["GEMINI_API_KEY"] = load_api_key("GEMINI")
+
+    app = QApplication(sys.argv)
+    app.setOrganizationName(APP_ORG); app.setApplicationName(APP_NAME)
+    w = MainWindow(); w.show()
+    sys.exit(app.exec())
+
+if __name__ == "__main__":
+    main()

--- a/app_src/requirements.txt
+++ b/app_src/requirements.txt
@@ -1,0 +1,7 @@
+PySide6
+pyinstaller
+requests
+beautifulsoup4
+lxml
+python-docx
+pywin32; platform_system=="Windows"

--- a/app_src/settings/__init__.py
+++ b/app_src/settings/__init__.py
@@ -1,0 +1,18 @@
+"""Settings utilities for DeepParser."""
+
+from .network import (
+    ProxySettings,
+    load_proxy_settings,
+    save_proxy_settings,
+    test_proxy_connection,
+)
+from .credentials import load_api_key, store_api_key
+
+__all__ = [
+    'ProxySettings',
+    'load_proxy_settings',
+    'save_proxy_settings',
+    'test_proxy_connection',
+    'load_api_key',
+    'store_api_key',
+]

--- a/app_src/settings/credentials.py
+++ b/app_src/settings/credentials.py
@@ -1,0 +1,50 @@
+"""API key storage with Windows DPAPI encryption."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "SETTINGS.json"
+
+if sys.platform == "win32":
+    import win32crypt
+
+
+def _encrypt(text: str) -> str:
+    if sys.platform == "win32":
+        blob = win32crypt.CryptProtectData(text.encode("utf-8"), None, None, None, None, 0)[1]
+        return base64.b64encode(blob).decode("utf-8")
+    return text
+
+
+def _decrypt(text: str) -> str:
+    if sys.platform == "win32" and text:
+        data = base64.b64decode(text)
+        blob = win32crypt.CryptUnprotectData(data, None, None, None, 0)[1]
+        return blob.decode("utf-8")
+    return text
+
+
+def store_api_key(provider: str, key: str) -> None:
+    """Encrypt and store API key for provider."""
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        data = {}
+    data.setdefault("api", {})[f"{provider}_API_KEY"] = _encrypt(key)
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def load_api_key(provider: str) -> str:
+    """Retrieve decrypted API key for provider."""
+    if not CONFIG_PATH.exists():
+        return ""
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    enc = data.get("api", {}).get(f"{provider}_API_KEY", "")
+    return _decrypt(enc) if enc else ""

--- a/app_src/settings/network.py
+++ b/app_src/settings/network.py
@@ -1,0 +1,73 @@
+"""Proxy configuration utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import requests
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "SETTINGS.json"
+
+
+@dataclass
+class ProxySettings:
+    """Container for proxy addresses."""
+
+    http: str = ""
+    https: str = ""
+
+    def as_dict(self) -> Dict[str, str]:
+        proxies: Dict[str, str] = {}
+        if self.http:
+            proxies["http"] = self.http
+        if self.https:
+            proxies["https"] = self.https
+        return proxies
+
+    def apply(self) -> None:
+        """Apply the proxy settings to environment variables."""
+        if self.http:
+            os.environ["HTTP_PROXY"] = self.http
+            os.environ["http_proxy"] = self.http
+        if self.https:
+            os.environ["HTTPS_PROXY"] = self.https
+            os.environ["https_proxy"] = self.https
+
+
+def load_proxy_settings() -> ProxySettings:
+    """Load proxy settings from configuration file."""
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        net = data.get("network", {})
+        return ProxySettings(net.get("http_proxy", ""), net.get("https_proxy", ""))
+    return ProxySettings()
+
+
+def save_proxy_settings(settings: ProxySettings) -> None:
+    """Persist proxy settings into configuration file."""
+    data = {}
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    data.setdefault("network", {})
+    data["network"]["http_proxy"] = settings.http
+    data["network"]["https_proxy"] = settings.https
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def test_proxy_connection(settings: ProxySettings, url: str = "https://www.google.com", timeout: int = 5) -> bool:
+    """Check whether the provided proxy settings can reach a URL."""
+    proxies = settings.as_dict()
+    if not proxies:
+        return True
+    try:
+        requests.get(url, proxies=proxies, timeout=timeout)
+        return True
+    except Exception:
+        return False

--- a/app_src/site_profiles.py
+++ b/app_src/site_profiles.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""
+site_profiles.py — профили сайтов (M2.1, fixed)
+- RoyalRoad (устойчивые селекторы)
+- MVLEmpyr
+- Novatls
+- Ellotl
+"""
+
+import re
+import urllib.parse
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0 Safari/537.36"
+}
+
+def get(url, **kw):
+    kw.setdefault("headers", HEADERS)
+    resp = requests.get(url, **kw, timeout=30)
+    resp.raise_for_status()
+    return resp
+
+def normalize_whitespace(text: str) -> str:
+    text = re.sub(r'\r\n?', '\n', text)
+    text = re.sub(r'\u00A0', ' ', text)
+    text = re.sub(r'[ \t]+', ' ', text)
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text.strip()
+
+def text_from_nodes(soup, selectors: List[str]) -> str:
+    for sel in selectors:
+        node = soup.select_one(sel)
+        if node:
+            for bad in node.select('script,style,ins,iframe,nav,header,footer'):
+                bad.decompose()
+            for br in node.find_all("br"):
+                br.replace_with("\n")
+            txt = node.get_text("\n", strip=False)
+            return normalize_whitespace(txt)
+    return ""
+
+@dataclass
+class Chapter:
+    title: str
+    url: str
+
+class BaseProfile:
+    domains: List[str] = []
+    def detect(self, url: str) -> bool:
+        host = urllib.parse.urlparse(url).netloc.lower()
+        return any(d in host for d in self.domains)
+    def parse_book(self, url: str) -> Tuple[str, List[Chapter]]:
+        raise NotImplementedError
+    def fetch_chapter(self, url: str) -> Tuple[str, str]:
+        raise NotImplementedError
+
+# ---------- RoyalRoad (fixed) ----------
+class RoyalRoadProfile(BaseProfile):
+    domains = ["royalroad.com", "www.royalroad.com"]
+
+    def _fiction_base(self, url: str) -> str:
+        p = urllib.parse.urlparse(url)
+        parts = p.path.strip("/").split("/")
+        if len(parts) >= 3 and parts[0] == "fiction":
+            base_path = "/" + "/".join(parts[:3])
+        else:
+            base_path = p.path
+        return urllib.parse.urlunparse((p.scheme, p.netloc, base_path, "", "", ""))
+
+    def parse_book(self, url: str) -> Tuple[str, List[Chapter]]:
+        r = get(url)
+        soup = BeautifulSoup(r.text, "lxml")
+
+        title_el = soup.select_one("h1.fiction-title, h1")
+        book_title = title_el.get_text(strip=True) if title_el else "RoyalRoad_Fiction"
+
+        base = self._fiction_base(url)
+        chapters: List[Chapter] = []
+
+        # Ссылки, начинающиеся с <base>/chapter/
+        for a in soup.select("a[href]"):
+            href = a.get("href")
+            if not href:
+                continue
+            abs_url = urllib.parse.urljoin(url, href)
+            if abs_url.startswith(base + "/chapter/"):
+                txt = a.get_text(strip=True)
+                if txt:
+                    chapters.append(Chapter(txt, abs_url))
+
+        # Запасной вариант
+        if not chapters:
+            for a in soup.select("table#chapters a, .chapter-list a, a.chapter-title"):
+                href = a.get("href")
+                if not href:
+                    continue
+                abs_url = urllib.parse.urljoin(url, href)
+                if "/chapter/" in abs_url:
+                    txt = a.get_text(strip=True)
+                    if txt:
+                        chapters.append(Chapter(txt, abs_url))
+
+        uniq, seen = [], set()
+        for ch in chapters:
+            if ch.url not in seen:
+                uniq.append(ch); seen.add(ch.url)
+        return book_title, uniq
+
+    def fetch_chapter(self, url: str) -> Tuple[str, str]:
+        r = get(url)
+        soup = BeautifulSoup(r.text, "lxml")
+        title = soup.select_one("h1.chapter-title, h1, .chapter-title")
+        ch_title = title.get_text(strip=True) if title else "Chapter"
+        body = text_from_nodes(
+            soup,
+            ["div.chapter-content", "div.chapter-inner", "div.fic-section", "article", "div#chapter-content"]
+        )
+        return ch_title, body
+
+# ---------- MVLEmpyr ----------
+class MVLEmpyrProfile(BaseProfile):
+    domains = ["mvlempyr.com", "www.mvlempyr.com"]
+    def parse_book(self, url: str) -> Tuple[str, List[Chapter]]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        title_el = soup.select_one("h1.entry-title, h1[class*=novel], h1")
+        book_title = title_el.get_text(strip=True) if title_el else "MVLEmpyr_Novel"
+        chapters: List[Chapter] = []
+        for a in soup.select(".chapter-list a, .epl-list a, .wp-block-list a, .su-posts a"):
+            txt = a.get_text(strip=True); href = a.get("href")
+            if href and txt:
+                chapters.append(Chapter(txt, urllib.parse.urljoin(url, href)))
+        if not chapters:
+            for a in soup.select("a[href]"):
+                href = a.get("href")
+                if href and "/chapter" in href:
+                    txt = a.get_text(strip=True)
+                    if txt:
+                        chapters.append(Chapter(txt, urllib.parse.urljoin(url, href)))
+        uniq, seen = [], set()
+        for ch in chapters:
+            if ch.url not in seen:
+                uniq.append(ch); seen.add(ch.url)
+        return book_title, uniq
+    def fetch_chapter(self, url: str) -> Tuple[str, str]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        t = soup.select_one("h1.entry-title, h1[class*=chapter], h1")
+        ch_title = t.get_text(strip=True) if t else "Chapter"
+        body = text_from_nodes(soup, ["article","div.entry-content","div#chapter-content","div.text-left"])
+        return ch_title, body
+
+# ---------- Novatls ----------
+class NovatlsProfile(BaseProfile):
+    domains = ["novatls.com", "www.novatls.com"]
+    def parse_book(self, url: str) -> Tuple[str, List[Chapter]]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        title_el = soup.select_one("h1.entry-title, h1")
+        book_title = title_el.get_text(strip=True) if title_el else "Novatls_Series"
+        chapters: List[Chapter] = []
+        for a in soup.select(".epl-list a, .chapter-list a, .wp-block-list a"):
+            txt = a.get_text(strip=True); href = a.get("href")
+            if href and txt:
+                chapters.append(Chapter(txt, urllib.parse.urljoin(url, href)))
+        if not chapters:
+            for a in soup.select("a[href*='/chapter']"):
+                txt = a.get_text(strip=True); href = a.get("href")
+                chapters.append(Chapter(txt, urllib.parse.urljoin(url, href)))
+        uniq, seen = [], set()
+        for ch in chapters:
+            if ch.url not in seen:
+                uniq.append(ch); seen.add(ch.url)
+        return book_title, uniq
+    def fetch_chapter(self, url: str) -> Tuple[str, str]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        t = soup.select_one("h1.entry-title, h1")
+        ch_title = t.get_text(strip=True) if t else "Chapter"
+        body = text_from_nodes(soup, ["article","div.entry-content","div#chapter-content"])
+        return ch_title, body
+
+# ---------- Ellotl ----------
+class EllotlProfile(BaseProfile):
+    domains = ["ellotl.com","www.ellotl.com"]
+    def parse_book(self, url: str) -> Tuple[str, List[Chapter]]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        title_el = soup.select_one("h1.entry-title, h1")
+        book_title = title_el.get_text(strip=True) if title_el else "Ellotl_Series"
+        chapters: List[Chapter] = []
+        for a in soup.select(".chapter-list a, .epl-list a, .wp-block-list a"):
+            txt = a.get_text(strip=True); href = a.get("href")
+            if href and txt:
+                chapters.append(Chapter(txt, urllib.parse.urljoin(url, href)))
+        uniq, seen = [], set()
+        for ch in chapters:
+            if ch.url not in seen:
+                uniq.append(ch); seen.add(ch.url)
+        return book_title, uniq
+    def fetch_chapter(self, url: str) -> Tuple[str, str]:
+        r = get(url); soup = BeautifulSoup(r.text, "lxml")
+        t = soup.select_one("h1.entry-title, h1")
+        ch_title = t.get_text(strip=True) if t else "Chapter"
+        body = text_from_nodes(soup, ["article","div.entry-content","div#chapter-content"])
+        return ch_title, body
+
+# Registry
+PROFILES = [RoyalRoadProfile(), MVLEmpyrProfile(), NovatlsProfile(), EllotlProfile()]
+
+def detect_profile(url: str) -> Optional[BaseProfile]:
+    for p in PROFILES:
+        if p.detect(url):
+            return p
+    return None

--- a/app_src/utils_docx.py
+++ b/app_src/utils_docx.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import re
+from pathlib import Path
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+INVALID = r'<>:"/\\|?*'
+
+def safe_name(name: str, maxlen: int = 120) -> str:
+    name = name.strip()
+    for ch in INVALID:
+        name = name.replace(ch, "_")
+    name = re.sub(r'\s+', ' ', name).strip()
+    if len(name) > maxlen:
+        name = name[:maxlen].rstrip()
+    return name or "chapter"
+
+def save_chapter_docx(folder: Path, chapter_title: str, text: str, index: int = None):
+    folder.mkdir(parents=True, exist_ok=True)
+    base = safe_name(chapter_title)
+    filename = f"{index:03d} {base}.docx" if index is not None else f"{base}.docx"
+    path = folder / filename
+    doc = Document()
+    h = doc.add_heading(chapter_title, level=1)
+    h.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    for line in text.split("\n"):
+        if line.strip():
+            doc.add_paragraph(line.strip())
+        else:
+            doc.add_paragraph()
+    doc.save(path)
+    return path


### PR DESCRIPTION
## Summary
- add `settings.network` for storing HTTP/HTTPS proxies and connection testing
- encrypt API keys using Windows DPAPI and load them at runtime
- apply proxy and decrypted key automatically when starting the app

## Testing
- `python -m py_compile app_src/settings/network.py app_src/settings/credentials.py app_src/app.py`
- `python -m py_compile app_src/site_profiles.py app_src/utils_docx.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a4caf736c8332ad96aad27ad50184